### PR TITLE
remove ga-click-event-implicit-count

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Google Analytics event tracking defined in HTML made easy. The plugin allows one
 | data-ga-click-event-action       			| optional   | [Action](https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide#Actions)       | Play
 | data-click-event-label					| optional   | [Label](https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide#Labels)         | Rick astley - never gonna give you up
 | data-ga-click-event-value					| optional   | [Value](https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide#Values)         | 3 (number of seconds)
-| data-ga-click-event-implicit-count		| optional   | [Implicit count](https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide#Count) |
 | data-ga-click-event-track-multiplicity	| optional   | Specifies how many times the event should be pushed for repeating actions - default 0 meaning every click will be tracked | 1
 
 More information: https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide

--- a/jquery.analytics.js
+++ b/jquery.analytics.js
@@ -40,7 +40,7 @@
             var $clickedElement = $(this);
 
             // GA parameters to be read from the element
-            var dataParemeters = ['ga-click-event-category', 'ga-click-event-action', 'ga-click-event-label', 'ga-click-event-value', 'ga-click-event-implicit-count'];
+            var dataParemeters = ['ga-click-event-category', 'ga-click-event-action', 'ga-click-event-label', 'ga-click-event-value'];
 
             // Data array initialization
             var data = ['_trackEvent'];


### PR DESCRIPTION
There seems to be a misunderstanding of GA docs - there is no "implicit count" parameter, that's a term for aggregation done server side.

What's more, "ga-click-event-implicit-count" was going in place of <a href="https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide#non-interaction">opt_noninteraction parameter</a>, which is not supported yet by this lib.
